### PR TITLE
Added ability to specify massah reporter

### DIFF
--- a/.massah.js
+++ b/.massah.js
@@ -12,6 +12,7 @@ module.exports = function(yargs) {
 
     return {
         runner: yargs.argv.runner || process.env.MASSAH_RUNNER || 'vanilla',
+        reporter: yargs.argv.reporter || process.env.MASSAH_REPORTER || 'spec',
         headless: false,
         match: {
             grep: '@dontRun',

--- a/cli/commands/test.js
+++ b/cli/commands/test.js
@@ -7,7 +7,7 @@ var run = function(config) {
 
     var options = {
         timeout: config.timeout || 60000,
-        reporter: 'spec'
+        reporter: config.reporter || 'spec'
     }
     if (config.bail) options.bail = true
     

--- a/cli/commands/test.js
+++ b/cli/commands/test.js
@@ -7,7 +7,8 @@ var run = function(config) {
 
     var options = {
         timeout: config.timeout || 60000,
-        reporter: config.reporter || 'spec'
+        reporter: config.reporter || 'spec',
+        reporterOptions: config.reporterOptions || {}
     }
     if (config.bail) options.bail = true
     

--- a/index.js
+++ b/index.js
@@ -78,20 +78,27 @@ new Yadda.FeatureFileSearch(featuresPath).each(function(file) {
         })
 
         after(function(done) {
+            console.log('Running after')
             afterFeature(function() {
+                console.log('Running afterFeature')
                 if (global && global.gc) {
                     log('Garbage collecting')
                     global.gc()
                 }
+                
+                console.log('Calling done')
                 done()
             })
             
         })
         
         before(function(done) {
+            console.log('Running before')
             helper.application.start(function(app) {
+                console.log('Running start-done')
                 application = app
                 helper.getBrowser(function(browser) {
+                  console.log('Got browser')
                   driver = browser
                   done()
                 })
@@ -155,9 +162,13 @@ function takeScreenshotOnFailure(test) {
 }
 
 var afterFeature = function(done) {
+    console.log('Running afterFeature fn')
     if (!driver)
         return helper.application.stop(done)
+        
+    console.log('Quitting driver')
     driver.quit().then(function() {
+        console.log('Driver quit')
         helper.application.stop(done)
     })
 }

--- a/index.js
+++ b/index.js
@@ -83,7 +83,6 @@ new Yadda.FeatureFileSearch(featuresPath).each(function(file) {
                     log('Garbage collecting')
                     global.gc()
                 }
-                
                 done()
             })
             
@@ -158,7 +157,6 @@ function takeScreenshotOnFailure(test) {
 var afterFeature = function(done) {
     if (!driver)
         return helper.application.stop(done)
-        
     driver.quit().then(function() {
         helper.application.stop(done)
     })

--- a/index.js
+++ b/index.js
@@ -78,27 +78,21 @@ new Yadda.FeatureFileSearch(featuresPath).each(function(file) {
         })
 
         after(function(done) {
-            console.log('Running after')
             afterFeature(function() {
-                console.log('Running afterFeature')
                 if (global && global.gc) {
                     log('Garbage collecting')
                     global.gc()
                 }
                 
-                console.log('Calling done')
                 done()
             })
             
         })
         
         before(function(done) {
-            console.log('Running before')
             helper.application.start(function(app) {
-                console.log('Running start-done')
                 application = app
                 helper.getBrowser(function(browser) {
-                  console.log('Got browser')
                   driver = browser
                   done()
                 })
@@ -162,13 +156,10 @@ function takeScreenshotOnFailure(test) {
 }
 
 var afterFeature = function(done) {
-    console.log('Running afterFeature fn')
     if (!driver)
         return helper.application.stop(done)
         
-    console.log('Quitting driver')
     driver.quit().then(function() {
-        console.log('Driver quit')
         helper.application.stop(done)
     })
 }


### PR DESCRIPTION
Added option to specify `reporter` in a `.massah.js` file, and associated `reporterOptions`, defaulting to `spec` and an empty object respectively.

This change was driven by a desire to use [xunit-file](https://www.npmjs.com/package/xunit-file) as a reporter.